### PR TITLE
Workflow's influence on cluster is now fully declarative

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Edit deployment.yaml
         run: |
           cp ./kube_configs/deployment.yaml ./kube_configs/deployment_old.yaml
-          sed -r -i 's/conormgomes\/liatrio_demo:.*/conormgomes\/liatrio_demo:'$TIME_NOW'/' deployment.yaml
+          sed -r -i 's/conormgomes\/liatrio_demo:.*/conormgomes\/liatrio_demo:'$TIME_NOW'/' ./kube_configs/deployment.yaml
       
       - name: Authenticate AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: Test, Build, and Push Docker image
 
 on:
   push:
-    branches: [ main, k8s-workflow ]
+    branches: [ main, declarative-testing ]
 
 jobs:
   build-test-push:
@@ -31,8 +31,10 @@ jobs:
           docker_pass: ${{secrets.DOCKER_PASSWORD}}
         run: docker login -u $docker_user -p $docker_pass
 
-      - name: Generate tag number
-        run: echo "TIME_NOW=$(date +%s)" >> $GITHUB_ENV
+      - name: Generate tag number and commit hash
+        run: |
+          echo "TIME_NOW=$(date +%s)" >> $GITHUB_ENV
+          echo "sha_short=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
 
       - name: Push to Docker Hub
         run: |
@@ -40,6 +42,11 @@ jobs:
           docker push conormgomes/liatrio_demo:$TIME_NOW
           docker tag git-image conormgomes/liatrio_demo:latest
           docker push conormgomes/liatrio_demo:latest
+
+      - name: Edit deployment.yaml
+        run: |
+          cp ./kube_configs/deployment.yaml ./kube_configs/deployment_old.yaml
+          sed -r -i 's/conormgomes\/liatrio_demo:.*/conormgomes\/liatrio_demo:'$TIME_NOW'/' deployment.yaml
       
       - name: Authenticate AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -60,4 +67,12 @@ jobs:
 
       - name: Update deployment with new image
         run: |
-          kubectl set image deployment/node-deployment node-app=conormgomes/liatrio_demo:$TIME_NOW
+          kubectl apply -f ./kube_configs/deployment.yaml
+
+      - name: Change deployment.yaml in repo
+        run: |
+          git config --global user.name 'conormgomes'
+          git config --global user.email 'gomesconor@gmail.com'
+          git add ./kube_configs/deployment.yaml ./kube_configs/deployment_old.yaml
+          git commit -m "Automated update of deployment.yaml for Commit ${{ env.sha_short }} [skip actions]"
+          git push origin declarative-testing

--- a/index.js
+++ b/index.js
@@ -5,9 +5,7 @@ const app = express();
 app.get('/', async (request, response) => {
 
     response.json({ message: "My name is Conor", 
-                    timestamp: Date.now(),
-                    k8s: "updated",
-                    workflow: "working"});
+                    timestamp: Date.now()});
 });
 
 app.listen(80, () => console.log('App available on http://localhost:80'));

--- a/kube_configs/deployment_old.yaml
+++ b/kube_configs/deployment_old.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: node-app
-          image: conormgomes/liatrio_demo:1728773285
+          image: conormgomes/liatrio_demo:latest
           ports:
             - containerPort: 80
           imagePullPolicy: Always


### PR DESCRIPTION
Workflow now:
1. creates a copy of the old deployment.yaml (named deployment_old.yaml)
2. edits origin deployment.yaml image variable to point at the new image on Dockerhub
3. applies this new deployment.yaml instead of just setting the image manually
4. automatically pushes the changed deployment and deployment_old to the repo